### PR TITLE
Add basic schedule generator frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "ff-schedule-protos": "^0.1.1",
         "next": "15.4.2",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -3245,6 +3246,11 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/ff-schedule-protos": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ff-schedule-protos/-/ff-schedule-protos-0.1.1.tgz",
+      "integrity": "sha512-rgp8p+ZdOxIKTRcM4gKeTuyKxLVG9CcnyGV7UmQFMxeZDKdV5PlrOsNjCf4P2u4wvZJrjMx3/XJe2gEvmD/5Sw=="
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "ff-schedule-protos": "^0.1.1",
+    "next": "15.4.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "next": "15.4.2"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.4.2",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/api/generate_schedule/route.ts
+++ b/src/app/api/generate_schedule/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { scheduler } from 'ff-schedule-protos/dist/scheduler'
+
+export async function POST(req: Request) {
+  const body = (await req.json()) as scheduler.IScheduleRequest
+  const api = process.env.API_URL
+  if (!api) {
+    return NextResponse.json({ error: 'API_URL not configured' }, { status: 500 })
+  }
+
+  const res = await fetch(`${api}/generate_schedule`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+
+  const data = await res.json()
+  return NextResponse.json(data, { status: res.status })
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,86 @@
-import Image from "next/image";
+'use client'
+
+import { useState } from 'react'
+import { scheduler } from 'ff-schedule-protos/dist/scheduler'
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [divisionsText, setDivisionsText] = useState('1,Division 1\n2,Division 2')
+  const [teamsText, setTeamsText] = useState('Team A,1\nTeam B,1\nTeam C,2\nTeam D,2')
+  const [schedule, setSchedule] = useState<scheduler.IScheduleResponse | null>(null)
+  const [loading, setLoading] = useState(false)
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+  const generate = async () => {
+    setLoading(true)
+    try {
+      const divisions: scheduler.IDivision[] = divisionsText.split('\n').map(line => {
+        const [id, name] = line.split(',')
+        return { id: Number(id), name: name.trim() }
+      })
+      const teams: scheduler.ITeam[] = teamsText.split('\n').map(line => {
+        const [name, div] = line.split(',')
+        return { name: name.trim(), divisionId: Number(div) }
+      })
+
+      const res = await fetch('/api/generate_schedule', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ league: teams, divisions })
+      })
+
+      if (res.ok) {
+        const data: scheduler.IScheduleResponse = await res.json()
+        setSchedule(data)
+      } else {
+        console.error('failed to generate schedule')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="p-8 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Fantasy Football Schedule Generator</h1>
+      <div className="mb-4">
+        <label className="block font-semibold mb-1">Divisions (id,name)</label>
+        <textarea
+          className="w-full border p-2"
+          rows={2}
+          value={divisionsText}
+          onChange={e => setDivisionsText(e.target.value)}
+        />
+      </div>
+      <div className="mb-4">
+        <label className="block font-semibold mb-1">Teams (name,division id)</label>
+        <textarea
+          className="w-full border p-2"
+          rows={4}
+          value={teamsText}
+          onChange={e => setTeamsText(e.target.value)}
+        />
+      </div>
+      <button
+        className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        onClick={generate}
+        disabled={loading}
+      >
+        {loading ? 'Generating...' : 'Generate Schedule'}
+      </button>
+
+      {schedule && schedule.matchups && (
+        <div className="mt-6 space-y-4">
+          {schedule.matchups.map((week, i) => (
+            <div key={i}>
+              <h2 className="font-semibold">Week {i + 1}</h2>
+              <ul className="list-disc list-inside">
+                {week.matchups?.map((m, j) => (
+                  <li key={j}>{m.team1?.name} vs {m.team2?.name}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
-  );
+      )}
+    </main>
+  )
 }


### PR DESCRIPTION
## Summary
- install ff-schedule-protos package
- remove google font usage
- implement schedule generator UI
- call backend using new API route

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ec7ac4b78832ea2e9093691e49a9f