### PR TITLE
Use API_URL env var for schedule API

### DIFF
--- a/src/app/api/generate_schedule/route.ts
+++ b/src/app/api/generate_schedule/route.ts
@@ -3,10 +3,7 @@ import { scheduler } from 'ff-schedule-protos/dist/scheduler'
 
 export async function POST(req: Request) {
   const body = (await req.json()) as scheduler.IScheduleRequest
-  const api = process.env.API_URL
-  if (!api) {
-    return NextResponse.json({ error: 'API_URL not configured' }, { status: 500 })
-  }
+  const api = process.env.API_URL || 'https://ff-scheduler-466320.uw.r.appspot.com'
 
   const res = await fetch(`${api}/generate_schedule`, {
     method: 'POST',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,11 @@ export default function Home() {
         return { name: name.trim(), divisionId: Number(div) }
       })
 
-      const res = await fetch('/api/generate_schedule', {
+      const api = process.env.NEXT_PUBLIC_API_URL ||
+                  process.env.API_URL ||
+                  'https://ff-scheduler-466320.uw.r.appspot.com'
+
+      const res = await fetch(`${api}/generate_schedule`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ league: teams, divisions })


### PR DESCRIPTION
## Summary
- make schedule generator API calls use `API_URL` env var if configured
- fallback to `https://ff-scheduler-466320.uw.r.appspot.com`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687eca287740832ebea2c1d6971bab87