### PR TITLE
Update API path

### DIFF
--- a/src/app/api/generate-schedule/route.ts
+++ b/src/app/api/generate-schedule/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'API_URL not configured' }, { status: 500 })
   }
 
-  const res = await fetch(`${api}/generate_schedule`, {
+  const res = await fetch(`${api}/generate-schedule`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
         return { name: name.trim(), divisionId: Number(div) }
       })
 
-      const res = await fetch('/api/generate_schedule', {
+      const res = await fetch('/api/generate-schedule', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ league: teams, divisions })


### PR DESCRIPTION
## Summary
- use `/generate-schedule` route for local API calls

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687eda3bb730832eaa011ef7dbe42790