### PR TITLE
Improve error handling for schedule API

### DIFF
--- a/src/app/api/generate-schedule/route.ts
+++ b/src/app/api/generate-schedule/route.ts
@@ -8,12 +8,22 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'API_URL not configured' }, { status: 500 })
   }
 
-  const res = await fetch(`${api}/generate-schedule`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
-  })
+  try {
+    const res = await fetch(`${api}/generate-schedule`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    })
 
-  const data = await res.json()
-  return NextResponse.json(data, { status: res.status })
+    let data: unknown = null
+    try {
+      data = await res.json()
+    } catch {
+      // ignore json parse errors
+    }
+
+    return NextResponse.json(data, { status: res.status })
+  } catch {
+    return NextResponse.json({ error: 'Failed to reach schedule service' }, { status: 500 })
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,8 @@ export default function Home() {
         const data: scheduler.IScheduleResponse = await res.json()
         setSchedule(data)
       } else {
-        setError('Failed to generate schedule')
+        const err = await res.json().catch(() => null)
+        setError(err?.error ?? 'Failed to generate schedule')
       }
     } catch {
       setError('Failed to generate schedule')


### PR DESCRIPTION
## Summary
- bubble server errors back to the client in generate-schedule API route
- surface server-provided error message on the home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687f21c6d57c832e9e9f660cd546e558