### PR TITLE
Add options to schedule generator UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
-        "ff-schedule-protos": "^0.1.1",
+        "ff-schedule-protos": "^0.3.1",
         "next": "15.4.2",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -3248,9 +3248,9 @@
       }
     },
     "node_modules/ff-schedule-protos": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ff-schedule-protos/-/ff-schedule-protos-0.1.1.tgz",
-      "integrity": "sha512-rgp8p+ZdOxIKTRcM4gKeTuyKxLVG9CcnyGV7UmQFMxeZDKdV5PlrOsNjCf4P2u4wvZJrjMx3/XJe2gEvmD/5Sw=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ff-schedule-protos/-/ff-schedule-protos-0.3.1.tgz",
+      "integrity": "sha512-5+5ZXI0F2BD/+vaHIJxUTkaZdWNjR4zmmq8JAXincAIBJ8MR4rx+mStB1LmEyuGHY1bzV59MPQ3VWZnJlJa/KQ=="
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "ff-schedule-protos": "^0.1.1",
+    "ff-schedule-protos": "^0.3.1",
     "next": "15.4.2",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,10 @@ export default function Home() {
   const [schedule, setSchedule] = useState<scheduler.IScheduleResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [options, setOptions] = useState<scheduler.IOptions>({
+    inDivisionPlayTwice: false,
+    outOfDivisionPlayOnce: false
+  })
 
   const addDivision = () => {
     const nextId = divisions.length ? Math.max(...divisions.map(d => Number(d.id))) + 1 : 1
@@ -52,7 +56,7 @@ export default function Home() {
       const res = await fetch('/api/generate-schedule', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ league: teams, divisions })
+        body: JSON.stringify({ league: teams, divisions, options })
       })
 
       if (res.ok) {
@@ -90,6 +94,28 @@ export default function Home() {
         <button className="mt-2 text-blue-600" onClick={addDivision}>
           Add Division
         </button>
+      </div>
+
+      <div className="mb-6">
+        <label className="block font-semibold mb-2">Options</label>
+        <label className="block">
+          <input
+            type="checkbox"
+            className="mr-2"
+            checked={options.inDivisionPlayTwice ?? false}
+            onChange={e => setOptions({ ...options, inDivisionPlayTwice: e.target.checked })}
+          />
+          Play teams in division twice
+        </label>
+        <label className="block mt-2">
+          <input
+            type="checkbox"
+            className="mr-2"
+            checked={options.outOfDivisionPlayOnce ?? false}
+            onChange={e => setOptions({ ...options, outOfDivisionPlayOnce: e.target.checked })}
+          />
+          Play teams out of division once
+        </label>
       </div>
 
       <div className="mb-6">


### PR DESCRIPTION
## Summary
- update `ff-schedule-protos` to 0.3.1 for new request options
- add UI controls to set schedule options
- send options in schedule generation request

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fadd09234832ebb9cccd6c40b747b