### PR TITLE
feat: modernize schedule generator UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "my-app",
       "version": "0.1.0",
       "dependencies": {
+        "@formkit/auto-animate": "^0.8.2",
         "ff-schedule-protos": "^0.3.1",
         "next": "15.4.2",
         "react": "19.1.0",
@@ -225,6 +226,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@formkit/auto-animate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@formkit/auto-animate/-/auto-animate-0.8.2.tgz",
+      "integrity": "sha512-SwPWfeRa5veb1hOIBMdzI+73te5puUBHmqqaF1Bu7FjvxlYSz/kJcZKSa9Cg60zL0uRNeJL2SbRxV6Jp6Q1nFQ==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@formkit/auto-animate": "^0.8.2",
     "ff-schedule-protos": "^0.3.1",
     "next": "15.4.2",
     "react": "19.1.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,5 +22,6 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), sans-serif;
+  transition: background 0.3s ease, color 0.3s ease;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { scheduler } from 'ff-schedule-protos/dist/scheduler'
+import { useAutoAnimate } from '@formkit/auto-animate/react'
 
 export default function Home() {
   const [divisions, setDivisions] = useState<scheduler.IDivision[]>([
@@ -79,108 +80,134 @@ export default function Home() {
     }
   }
 
+  const [divisionsRef] = useAutoAnimate()
+  const [teamsRef] = useAutoAnimate()
+  const [scheduleRef] = useAutoAnimate()
+
   return (
-    <main className="p-8 max-w-xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Fantasy Football Schedule Generator</h1>
-      <div className="mb-6">
-        <label className="block font-semibold mb-2">Divisions</label>
-        {divisions.map(div => (
-          <div key={div.id} className="flex items-center mb-2">
-            <input
-              className="border p-1 flex-grow"
-              value={div.name ?? ''}
-              placeholder="Division name"
-              onChange={e => updateDivisionName(Number(div.id), e.target.value)}
-            />
-            <button className="ml-2 text-red-600" onClick={() => removeDivision(Number(div.id))}>
-              Remove
-            </button>
+    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 dark:from-gray-900 dark:to-gray-800 p-6 flex items-start justify-center">
+      <section className="w-full max-w-2xl bg-white/70 dark:bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-8">
+        <h1 className="text-3xl font-bold mb-8 text-center">
+          Fantasy Football Schedule Generator
+        </h1>
+
+        <div className="mb-8">
+          <label className="block font-semibold mb-2">Divisions</label>
+          <div className="space-y-2" ref={divisionsRef}>
+            {divisions.map(div => (
+              <div key={div.id} className="flex items-center p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                <input
+                  className="border rounded px-3 py-2 flex-grow focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                  value={div.name ?? ''}
+                  placeholder="Division name"
+                  onChange={e => updateDivisionName(Number(div.id), e.target.value)}
+                />
+                <button
+                  className="ml-2 text-red-500 hover:text-red-700 transition-colors"
+                  onClick={() => removeDivision(Number(div.id))}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
           </div>
-        ))}
-        <button className="mt-2 text-blue-600" onClick={addDivision}>
-          Add Division
-        </button>
-      </div>
-
-      <div className="mb-6">
-        <label className="block font-semibold mb-2">Options</label>
-        <label className="block">
-          <input
-            type="checkbox"
-            className="mr-2"
-            checked={options.inDivisionPlayTwice ?? false}
-            onChange={e => setOptions({ ...options, inDivisionPlayTwice: e.target.checked })}
-          />
-          Play teams in division twice
-        </label>
-        <label className="block mt-2">
-          <input
-            type="checkbox"
-            className="mr-2"
-            checked={options.outOfDivisionPlayOnce ?? false}
-            onChange={e => setOptions({ ...options, outOfDivisionPlayOnce: e.target.checked })}
-          />
-          Play teams out of division once
-        </label>
-      </div>
-
-      <div className="mb-6">
-        <label className="block font-semibold mb-2">Teams</label>
-        {teams.map((team, idx) => (
-          <div key={idx} className="flex items-center mb-2">
-            <input
-              className="border p-1 flex-grow"
-              value={team.name ?? ''}
-              placeholder="Team name"
-              onChange={e => updateTeam(idx, { name: e.target.value })}
-            />
-            <select
-              className="border p-1 ml-2"
-              value={Number(team.divisionId)}
-              onChange={e => updateTeam(idx, { divisionId: Number(e.target.value) })}
-            >
-              {divisions.map(div => (
-                <option key={div.id} value={div.id}>
-                  {div.name || `Division ${div.id}`}
-                </option>
-              ))}
-            </select>
-            <button className="ml-2 text-red-600" onClick={() => removeTeam(idx)}>
-              Remove
-            </button>
-          </div>
-        ))}
-        <button className="mt-2 text-blue-600" onClick={addTeam}>
-          Add Team
-        </button>
-      </div>
-
-      <button
-        className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
-        onClick={generate}
-        disabled={loading}
-      >
-        {loading ? 'Generating...' : 'Generate Schedule'}
-      </button>
-
-      {error && (
-        <p className="text-red-600 mt-4">{error}</p>
-      )}
-
-      {schedule && schedule.matchups && (
-        <div className="mt-6 space-y-4">
-          {schedule.matchups.map((week, i) => (
-            <div key={i}>
-              <h2 className="font-semibold">Week {i + 1}</h2>
-              <ul className="list-disc list-inside">
-                {week.matchups?.map((m, j) => (
-                  <li key={j}>{m.team1?.name} vs {m.team2?.name}</li>
-                ))}
-              </ul>
-            </div>
-          ))}
+          <button
+            className="mt-2 text-blue-600 hover:text-blue-800 transition-colors"
+            onClick={addDivision}
+          >
+            Add Division
+          </button>
         </div>
-      )}
+
+        <div className="mb-8 space-y-2">
+          <label className="block font-semibold">Options</label>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              checked={options.inDivisionPlayTwice ?? false}
+              onChange={e => setOptions({ ...options, inDivisionPlayTwice: e.target.checked })}
+            />
+            Play teams in division twice
+          </label>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              checked={options.outOfDivisionPlayOnce ?? false}
+              onChange={e => setOptions({ ...options, outOfDivisionPlayOnce: e.target.checked })}
+            />
+            Play teams out of division once
+          </label>
+        </div>
+
+        <div className="mb-8">
+          <label className="block font-semibold mb-2">Teams</label>
+          <div className="space-y-2" ref={teamsRef}>
+            {teams.map((team, idx) => (
+              <div key={idx} className="flex items-center p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                <input
+                  className="border rounded px-3 py-2 flex-grow focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                  value={team.name ?? ''}
+                  placeholder="Team name"
+                  onChange={e => updateTeam(idx, { name: e.target.value })}
+                />
+                <select
+                  className="border rounded px-3 py-2 ml-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                  value={Number(team.divisionId)}
+                  onChange={e => updateTeam(idx, { divisionId: Number(e.target.value) })}
+                >
+                  {divisions.map(div => (
+                    <option key={div.id} value={div.id}>
+                      {div.name || `Division ${div.id}`}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  className="ml-2 text-red-500 hover:text-red-700 transition-colors"
+                  onClick={() => removeTeam(idx)}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            className="mt-2 text-blue-600 hover:text-blue-800 transition-colors"
+            onClick={addTeam}
+          >
+            Add Team
+          </button>
+        </div>
+
+        <button
+          className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          onClick={generate}
+          disabled={loading}
+        >
+          {loading ? 'Generating...' : 'Generate Schedule'}
+        </button>
+
+        {error && <p className="text-red-600 mt-4">{error}</p>}
+
+        {schedule && schedule.matchups && (
+          <div className="mt-8 space-y-4" ref={scheduleRef}>
+            {schedule.matchups.map((week, i) => (
+              <div
+                key={i}
+                className="p-4 rounded-lg bg-gray-50 dark:bg-gray-800 shadow transition-shadow hover:shadow-md"
+              >
+                <h2 className="font-semibold mb-2">Week {i + 1}</h2>
+                <ul className="list-disc list-inside space-y-1">
+                  {week.matchups?.map((m, j) => (
+                    <li key={j}>{m.team1?.name} vs {m.team2?.name}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- integrate auto-animate and overhaul styles for a sleek modern look
- add smooth transitions and hover states for inputs, buttons, and results
- refine global styles for improved fonts and color transitions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892d5526b50832e8a85393bc65e524c