### PR TITLE
feat: modernize UI

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,44 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
+  --background: #f8fafc;
+  --background-secondary: #e0e7ff;
   --foreground: #171717;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: ui-sans-serif, system-ui, sans-serif;
+  --font-mono: ui-monospace, monospace;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #0f172a;
+    --background-secondary: #1e293b;
     --foreground: #ededed;
   }
 }
 
 body {
-  background: var(--background);
+  min-height: 100vh;
+  background: linear-gradient(135deg, var(--background), var(--background-secondary));
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.4s ease-out both;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,107 +80,118 @@ export default function Home() {
   }
 
   return (
-    <main className="p-8 max-w-xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Fantasy Football Schedule Generator</h1>
-      <div className="mb-6">
-        <label className="block font-semibold mb-2">Divisions</label>
-        {divisions.map(div => (
-          <div key={div.id} className="flex items-center mb-2">
-            <input
-              className="border p-1 flex-grow"
-              value={div.name ?? ''}
-              placeholder="Division name"
-              onChange={e => updateDivisionName(Number(div.id), e.target.value)}
-            />
-            <button className="ml-2 text-red-600" onClick={() => removeDivision(Number(div.id))}>
-              Remove
-            </button>
-          </div>
-        ))}
-        <button className="mt-2 text-blue-600" onClick={addDivision}>
-          Add Division
-        </button>
-      </div>
+    <main className="min-h-screen flex items-center justify-center p-4">
+      <div className="w-full max-w-3xl bg-white/80 dark:bg-gray-800/80 backdrop-blur rounded-xl shadow-xl p-8 space-y-8 animate-fade-in">
+        <h1 className="text-3xl font-bold text-center">Fantasy Football Schedule Generator</h1>
 
-      <div className="mb-6">
-        <label className="block font-semibold mb-2">Options</label>
-        <label className="block">
-          <input
-            type="checkbox"
-            className="mr-2"
-            checked={options.inDivisionPlayTwice ?? false}
-            onChange={e => setOptions({ ...options, inDivisionPlayTwice: e.target.checked })}
-          />
-          Play teams in division twice
-        </label>
-        <label className="block mt-2">
-          <input
-            type="checkbox"
-            className="mr-2"
-            checked={options.outOfDivisionPlayOnce ?? false}
-            onChange={e => setOptions({ ...options, outOfDivisionPlayOnce: e.target.checked })}
-          />
-          Play teams out of division once
-        </label>
-      </div>
-
-      <div className="mb-6">
-        <label className="block font-semibold mb-2">Teams</label>
-        {teams.map((team, idx) => (
-          <div key={idx} className="flex items-center mb-2">
-            <input
-              className="border p-1 flex-grow"
-              value={team.name ?? ''}
-              placeholder="Team name"
-              onChange={e => updateTeam(idx, { name: e.target.value })}
-            />
-            <select
-              className="border p-1 ml-2"
-              value={Number(team.divisionId)}
-              onChange={e => updateTeam(idx, { divisionId: Number(e.target.value) })}
-            >
-              {divisions.map(div => (
-                <option key={div.id} value={div.id}>
-                  {div.name || `Division ${div.id}`}
-                </option>
-              ))}
-            </select>
-            <button className="ml-2 text-red-600" onClick={() => removeTeam(idx)}>
-              Remove
-            </button>
-          </div>
-        ))}
-        <button className="mt-2 text-blue-600" onClick={addTeam}>
-          Add Team
-        </button>
-      </div>
-
-      <button
-        className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
-        onClick={generate}
-        disabled={loading}
-      >
-        {loading ? 'Generating...' : 'Generate Schedule'}
-      </button>
-
-      {error && (
-        <p className="text-red-600 mt-4">{error}</p>
-      )}
-
-      {schedule && schedule.matchups && (
-        <div className="mt-6 space-y-4">
-          {schedule.matchups.map((week, i) => (
-            <div key={i}>
-              <h2 className="font-semibold">Week {i + 1}</h2>
-              <ul className="list-disc list-inside">
-                {week.matchups?.map((m, j) => (
-                  <li key={j}>{m.team1?.name} vs {m.team2?.name}</li>
-                ))}
-              </ul>
+        <section className="space-y-2">
+          <label className="block font-semibold">Divisions</label>
+          {divisions.map(div => (
+            <div key={div.id} className="flex items-center gap-2">
+              <input
+                className="border rounded-md p-2 flex-grow focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
+                value={div.name ?? ''}
+                placeholder="Division name"
+                onChange={e => updateDivisionName(Number(div.id), e.target.value)}
+              />
+              <button
+                className="text-red-500 hover:text-red-700 transition-colors"
+                onClick={() => removeDivision(Number(div.id))}
+              >
+                Remove
+              </button>
             </div>
           ))}
+          <button className="text-blue-600 hover:text-blue-800 transition-colors" onClick={addDivision}>
+            Add Division
+          </button>
+        </section>
+
+        <section className="space-y-2">
+          <label className="block font-semibold">Options</label>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2 h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
+              checked={options.inDivisionPlayTwice ?? false}
+              onChange={e => setOptions({ ...options, inDivisionPlayTwice: e.target.checked })}
+            />
+            Play teams in division twice
+          </label>
+          <label className="flex items-center">
+            <input
+              type="checkbox"
+              className="mr-2 h-4 w-4 text-blue-600 rounded focus:ring-blue-500"
+              checked={options.outOfDivisionPlayOnce ?? false}
+              onChange={e => setOptions({ ...options, outOfDivisionPlayOnce: e.target.checked })}
+            />
+            Play teams out of division once
+          </label>
+        </section>
+
+        <section className="space-y-2">
+          <label className="block font-semibold">Teams</label>
+          {teams.map((team, idx) => (
+            <div key={idx} className="flex items-center gap-2">
+              <input
+                className="border rounded-md p-2 flex-grow focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
+                value={team.name ?? ''}
+                placeholder="Team name"
+                onChange={e => updateTeam(idx, { name: e.target.value })}
+              />
+              <select
+                className="border rounded-md p-2 focus:outline-none focus:ring-2 focus:ring-blue-500 transition"
+                value={Number(team.divisionId)}
+                onChange={e => updateTeam(idx, { divisionId: Number(e.target.value) })}
+              >
+                {divisions.map(div => (
+                  <option key={div.id} value={div.id}>
+                    {div.name || `Division ${div.id}`}
+                  </option>
+                ))}
+              </select>
+              <button
+                className="text-red-500 hover:text-red-700 transition-colors"
+                onClick={() => removeTeam(idx)}
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+          <button className="text-blue-600 hover:text-blue-800 transition-colors" onClick={addTeam}>
+            Add Team
+          </button>
+        </section>
+
+        <div className="pt-4">
+          <button
+            className="w-full bg-blue-600 hover:bg-blue-700 transition-colors text-white px-4 py-2 rounded-md shadow-md disabled:opacity-50"
+            onClick={generate}
+            disabled={loading}
+          >
+            {loading ? 'Generating...' : 'Generate Schedule'}
+          </button>
         </div>
-      )}
+
+        {error && (
+          <p className="text-red-500 text-center animate-fade-in">{error}</p>
+        )}
+
+        {schedule && schedule.matchups && (
+          <div className="mt-6 space-y-4 animate-fade-in">
+            {schedule.matchups.map((week, i) => (
+              <div key={i}>
+                <h2 className="font-semibold">Week {i + 1}</h2>
+                <ul className="list-disc list-inside">
+                  {week.matchups?.map((m, j) => (
+                    <li key={j}>{m.team1?.name} vs {m.team2?.name}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- modernize schedule generator UI with card layout and smooth transitions
- add gradient background and reusable fade-in animation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892d5526b50832e8a85393bc65e524c