### PR TITLE
feat: allow configuring number of schedule weeks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@formkit/auto-animate": "^0.8.2",
-        "ff-schedule-protos": "^0.3.1",
+        "ff-schedule-protos": "^0.4.1",
         "next": "15.4.2",
         "react": "19.1.0",
         "react-dom": "19.1.0"
@@ -3255,9 +3255,9 @@
       }
     },
     "node_modules/ff-schedule-protos": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ff-schedule-protos/-/ff-schedule-protos-0.3.1.tgz",
-      "integrity": "sha512-5+5ZXI0F2BD/+vaHIJxUTkaZdWNjR4zmmq8JAXincAIBJ8MR4rx+mStB1LmEyuGHY1bzV59MPQ3VWZnJlJa/KQ=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/ff-schedule-protos/-/ff-schedule-protos-0.4.1.tgz",
+      "integrity": "sha512-a0BPVCnxFHZsw8tz5XHmyDGk6fHwuHF6zP+eFY9qOShGDNkI8sOyXTvo0kWgt6+vWxpA5Me1Fg/oWEcAor8IQg=="
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@formkit/auto-animate": "^0.8.2",
-    "ff-schedule-protos": "^0.3.1",
+    "ff-schedule-protos": "^0.4.1",
     "next": "15.4.2",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,8 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null)
   const [options, setOptions] = useState<scheduler.IOptions>({
     inDivisionPlayTwice: false,
-    outOfDivisionPlayOnce: false
+    outOfDivisionPlayOnce: false,
+    numWeeks: 13
   })
   const [selectedWeek, setSelectedWeek] = useState(0)
 
@@ -162,6 +163,16 @@ export default function Home() {
               onChange={e => setOptions({ ...options, outOfDivisionPlayOnce: e.target.checked })}
             />
             Play teams out of division once
+          </label>
+          <label className="flex items-center">
+            <span className="mr-2">Number of weeks</span>
+            <input
+              type="number"
+              min={1}
+              className="border rounded px-3 py-2 w-24 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+              value={options.numWeeks ?? 13}
+              onChange={e => setOptions({ ...options, numWeeks: Number(e.target.value) })}
+            />
           </label>
         </div>
 


### PR DESCRIPTION
## Summary
- allow choosing number of weeks when generating schedules
- upgrade ff-schedule-protos to v0.4.1 to support week option

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892e10e9638832e8b832dca090a57bb