### PR TITLE
Add about page with scheduler constraints

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "About - FF Schedule Generator",
+};
+
+export default function About() {
+  return (
+    <main className="p-6 max-w-2xl mx-auto">
+      <h1 className="text-3xl font-bold mb-4">About the Scheduler</h1>
+      <p className="mb-4">
+        The Fantasy Football Schedule Generator creates balanced matchups using several constraints:
+      </p>
+      <ul className="list-disc pl-6 space-y-2">
+        <li>Every team plays every week.</li>
+        <li>No team has repeat matchups within any 4 week span.</li>
+        <li>
+          Soft constraint: out-of-division matchups are avoided in the final two weeks of the season when possible.
+        </li>
+      </ul>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -14,6 +15,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased">
+        <nav className="p-4 space-x-4">
+          <Link href="/">Home</Link>
+          <Link href="/about">About</Link>
+        </nav>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- add about page outlining scheduler rules
- add navigation links for home and about

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689365e0f61c832ea5aec91b38c8b8d6