### PR TITLE
test: add basic playwright e2e

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.54.2",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -972,6 +973,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3339,6 +3356,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -4987,6 +5019,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "playwright test"
   },
   "dependencies": {
     "@formkit/auto-animate": "^0.8.2",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.54.2",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run dev -- --port=3000',
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+});

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+
+test('allows schedule generation and team/division management', async ({ page }) => {
+  await page.route('**/api/generate-schedule', route => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        matchups: [
+          { matchups: [{ team1: { name: 'Team 1' }, team2: { name: 'Team 2' } }] }
+        ]
+      }),
+    });
+  });
+
+  await page.goto('/');
+
+  const divisionInputs = page.getByPlaceholder('Division name');
+  await expect(divisionInputs).toHaveCount(2);
+  await page.getByRole('button', { name: 'Add Division' }).click();
+  await expect(divisionInputs).toHaveCount(3);
+  await divisionInputs.last().locator('..').getByRole('button', { name: 'Remove' }).click();
+  await expect(divisionInputs).toHaveCount(2);
+
+  const teamInputs = page.getByPlaceholder('Team name');
+  await expect(teamInputs).toHaveCount(10);
+  await page.getByRole('button', { name: 'Add Team' }).click();
+  await expect(teamInputs).toHaveCount(11);
+  const newTeam = teamInputs.last();
+  await newTeam.fill('Temp');
+  await newTeam.locator('..').getByRole('button', { name: 'Remove' }).click();
+  await expect(teamInputs).toHaveCount(10);
+
+  await page.getByLabel('Play teams in division twice').check();
+  await page.getByLabel('Play teams out of division once').check();
+  const weeksInput = page.getByLabel('Number of weeks');
+  await weeksInput.fill('12');
+  await expect(weeksInput).toHaveValue('12');
+
+  await page.getByRole('button', { name: 'Generate Schedule' }).click();
+  await expect(page.getByText('Week 1')).toBeVisible();
+  await expect(page.getByText('Team 1')).toBeVisible();
+  await expect(page.getByText('Team 2')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add Playwright test covering schedule generation, team and division management, and option toggles
- configure Playwright with a dev server and add npm test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936e3b0fe4832eb2fb11eca6da48be