### PR TITLE
Add daily Playwright test workflow

### DIFF
--- a/.github/workflows/playwright-daily.yml
+++ b/.github/workflows/playwright-daily.yml
@@ -1,0 +1,22 @@
+name: Daily Playwright Tests
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm test
+        env:
+          CI: true
+          PLAYWRIGHT_TEST_BASE_URL: https://ff-schedule-generator-fe.vercel.app

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,15 +1,22 @@
 import { defineConfig } from '@playwright/test';
 
+const baseURL =
+  process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3000';
+
+const webServer = process.env.PLAYWRIGHT_TEST_BASE_URL
+  ? undefined
+  : {
+      command: 'npm run dev -- --port=3000',
+      port: 3000,
+      reuseExistingServer: !process.env.CI,
+      timeout: 120 * 1000,
+    };
+
 export default defineConfig({
   testDir: './tests',
-  webServer: {
-    command: 'npm run dev -- --port=3000',
-    port: 3000,
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  },
+  ...(webServer ? { webServer } : {}),
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL,
     headless: true,
   },
 });


### PR DESCRIPTION
## Summary
- make Playwright config use `PLAYWRIGHT_TEST_BASE_URL` to skip dev server when running against prod
- add scheduled workflow to run Playwright tests daily against deployed app

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689372adb658832e94ba2657356c31ea