### PR TITLE
chore: refine UI styling for sleek design

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,18 +6,20 @@ export const metadata: Metadata = {
 
 export default function About() {
   return (
-    <main className="p-6 max-w-2xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">About the Scheduler</h1>
-      <p className="mb-4">
-        The Fantasy Football Schedule Generator creates balanced matchups using several constraints:
-      </p>
-      <ul className="list-disc pl-6 space-y-2">
-        <li>Every team plays every week.</li>
-        <li>No team has repeat matchups within any 4 week span.</li>
-        <li>
-          Soft constraint: out-of-division matchups are avoided in the final two weeks of the season when possible.
-        </li>
-      </ul>
+    <main className="flex min-h-screen items-start justify-center p-6">
+      <section className="w-full max-w-3xl rounded-2xl bg-white/80 p-8 shadow-xl ring-1 ring-black/5 backdrop-blur-xl dark:bg-gray-950/40 dark:ring-white/10">
+        <h1 className="mb-4 text-center text-4xl font-semibold text-gray-900 dark:text-gray-100">About the Scheduler</h1>
+        <p className="mb-4 text-gray-700 dark:text-gray-300">
+          The Fantasy Football Schedule Generator creates balanced matchups using several constraints:
+        </p>
+        <ul className="list-disc space-y-2 pl-6 text-gray-700 dark:text-gray-300">
+          <li>Every team plays every week.</li>
+          <li>No team has repeat matchups within any 4 week span.</li>
+          <li>
+            Soft constraint: out-of-division matchups are avoided in the final two weeks of the season when possible.
+          </li>
+        </ul>
+      </section>
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,10 +14,20 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
-        <nav className="p-4 space-x-4">
-          <Link href="/">Home</Link>
-          <Link href="/about">About</Link>
+      <body className="antialiased min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-950 text-gray-900 dark:text-gray-100">
+        <nav className="sticky top-0 z-50 flex justify-center gap-6 py-4 backdrop-blur-md bg-white/70 dark:bg-gray-900/70 border-b border-gray-200/50 dark:border-gray-800/50">
+          <Link
+            href="/"
+            className="text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors"
+          >
+            Home
+          </Link>
+          <Link
+            href="/about"
+            className="text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors"
+          >
+            About
+          </Link>
         </nav>
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -110,25 +110,28 @@ export default function Home() {
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 dark:from-gray-900 dark:to-gray-800 p-6 flex items-start justify-center">
-      <section className="w-full max-w-2xl bg-white/70 dark:bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-8">
-        <h1 className="text-3xl font-bold mb-8 text-center">
+    <main className="min-h-screen flex items-start justify-center p-6 bg-gradient-to-br from-gray-100 via-gray-50 to-gray-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
+      <section className="w-full max-w-3xl bg-white/80 dark:bg-gray-950/40 backdrop-blur-xl rounded-2xl shadow-xl ring-1 ring-black/5 dark:ring-white/10 p-8 md:p-10">
+        <h1 className="mb-8 text-center text-4xl font-semibold text-gray-900 dark:text-gray-100">
           Fantasy Football Schedule Generator
         </h1>
 
         <div className="mb-8">
-          <label className="block font-semibold mb-2">Divisions</label>
+          <label className="mb-2 block text-sm font-semibold text-gray-700 dark:text-gray-300">Divisions</label>
           <div className="space-y-2" ref={divisionsRef}>
             {divisions.map(div => (
-              <div key={div.id} className="flex items-center p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+              <div
+                key={div.id}
+                className="flex items-center rounded-lg p-2 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800/70"
+              >
                 <input
-                  className="border rounded px-3 py-2 flex-grow focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                  className="flex-grow rounded-md border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-500"
                   value={div.name ?? ''}
                   placeholder="Division name"
                   onChange={e => updateDivisionName(Number(div.id), e.target.value)}
                 />
                 <button
-                  className="ml-2 text-red-500 hover:text-red-700 transition-colors"
+                  className="ml-2 text-sm text-red-500 transition-colors hover:text-red-700"
                   onClick={() => removeDivision(Number(div.id))}
                 >
                   Remove
@@ -137,7 +140,7 @@ export default function Home() {
             ))}
           </div>
           <button
-            className="mt-2 text-blue-600 hover:text-blue-800 transition-colors"
+            className="mt-3 text-sm font-medium text-blue-600 transition-colors hover:text-blue-800"
             onClick={addDivision}
           >
             Add Division
@@ -145,31 +148,31 @@ export default function Home() {
         </div>
 
         <div className="mb-8 space-y-2">
-          <label className="block font-semibold">Options</label>
-          <label className="flex items-center">
+          <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300">Options</label>
+          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
             <input
               type="checkbox"
-              className="mr-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600"
               checked={options.inDivisionPlayTwice ?? false}
               onChange={e => setOptions({ ...options, inDivisionPlayTwice: e.target.checked })}
             />
             Play teams in division twice
           </label>
-          <label className="flex items-center">
+          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
             <input
               type="checkbox"
-              className="mr-2 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500 dark:border-gray-600"
               checked={options.outOfDivisionPlayOnce ?? false}
               onChange={e => setOptions({ ...options, outOfDivisionPlayOnce: e.target.checked })}
             />
             Play teams out of division once
           </label>
-          <label className="flex items-center">
-            <span className="mr-2">Number of weeks</span>
+          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <span>Number of weeks</span>
             <input
               type="number"
               min={1}
-              className="border rounded px-3 py-2 w-24 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+              className="w-24 rounded-md border border-gray-300 bg-transparent px-3 py-2 text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors dark:border-gray-600 dark:text-gray-100"
               value={options.numWeeks ?? 13}
               onChange={e => setOptions({ ...options, numWeeks: Number(e.target.value) })}
             />
@@ -177,18 +180,21 @@ export default function Home() {
         </div>
 
         <div className="mb-8">
-          <label className="block font-semibold mb-2">Teams</label>
+          <label className="mb-2 block text-sm font-semibold text-gray-700 dark:text-gray-300">Teams</label>
           <div className="space-y-2" ref={teamsRef}>
             {teams.map((team, idx) => (
-              <div key={idx} className="flex items-center p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+              <div
+                key={idx}
+                className="flex items-center rounded-lg p-2 transition-colors hover:bg-gray-100 dark:hover:bg-gray-800/70"
+              >
                 <input
-                  className="border rounded px-3 py-2 flex-grow focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                  className="flex-grow rounded-md border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-500"
                   value={team.name ?? ''}
                   placeholder="Team name"
                   onChange={e => updateTeam(idx, { name: e.target.value })}
                 />
                 <select
-                  className="border rounded px-3 py-2 ml-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                  className="ml-2 rounded-md border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
                   value={Number(team.divisionId)}
                   onChange={e => updateTeam(idx, { divisionId: Number(e.target.value) })}
                 >
@@ -199,7 +205,7 @@ export default function Home() {
                   ))}
                 </select>
                 <button
-                  className="ml-2 text-red-500 hover:text-red-700 transition-colors"
+                  className="ml-2 text-sm text-red-500 transition-colors hover:text-red-700"
                   onClick={() => removeTeam(idx)}
                 >
                   Remove
@@ -208,7 +214,7 @@ export default function Home() {
             ))}
           </div>
           <button
-            className="mt-2 text-blue-600 hover:text-blue-800 transition-colors"
+            className="mt-3 text-sm font-medium text-blue-600 transition-colors hover:text-blue-800"
             onClick={addTeam}
           >
             Add Team
@@ -216,7 +222,7 @@ export default function Home() {
         </div>
 
         <button
-          className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="rounded-xl bg-blue-600 px-6 py-2 text-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-blue-700 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50"
           onClick={generate}
           disabled={loading}
         >
@@ -227,15 +233,15 @@ export default function Home() {
 
         {schedule && schedule.matchups && (
           <div className="mt-8">
-            <div className="flex flex-wrap gap-2 mb-4">
+            <div className="mb-4 flex flex-wrap gap-2">
               {schedule.matchups.map((_, i) => (
                 <button
                   key={i}
                   onClick={() => setSelectedWeek(i)}
-                  className={`px-3 py-1 rounded-full text-sm transition-colors ${
+                  className={`rounded-full px-3 py-1 text-sm transition-colors duration-200 ${
                     selectedWeek === i
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600'
+                      ? 'bg-blue-600 text-white shadow'
+                      : 'bg-gray-200 text-gray-700 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600'
                   }`}
                 >
                   Week {i + 1}
@@ -244,7 +250,7 @@ export default function Home() {
             </div>
             <button
               onClick={downloadCSV}
-              className="mb-4 bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors"
+              className="mb-4 rounded-lg bg-green-600 px-4 py-2 text-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-green-700 hover:shadow-md"
             >
               Download CSV
             </button>
@@ -252,7 +258,7 @@ export default function Home() {
               {schedule.matchups[selectedWeek]?.matchups?.map((m, j) => (
                 <div
                   key={j}
-                  className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800 shadow"
+                  className="flex items-center justify-between rounded-lg bg-gray-50 p-3 shadow-sm dark:bg-gray-800"
                 >
                   <span>{m.team1?.name}</span>
                   <span className="text-gray-500">vs</span>


### PR DESCRIPTION
## Summary
- apply translucent gradient background and premium navigation bar
- restyle schedule generator page with refined cards, spacing, and interactive elements
- update about page to match minimal aesthetic

## Testing
- `npm run lint`
- `npm test` *(fails: Playwright browser binaries missing; attempted install but downloads forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68937c8dc5c0832ea7ee6f0597562377