### PR TITLE
style: polish schedule generator ui

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -110,9 +110,9 @@ export default function Home() {
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 dark:from-gray-900 dark:to-gray-800 p-6 flex items-start justify-center">
-      <section className="w-full max-w-2xl bg-white/70 dark:bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-8">
-        <h1 className="text-3xl font-bold mb-8 text-center">
+    <main className="min-h-screen w-full bg-gradient-to-br from-gray-100 via-gray-50 to-gray-200 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 px-4 py-8 flex items-start justify-center text-gray-900 dark:text-gray-100">
+      <section className="w-full max-w-2xl bg-white/80 dark:bg-gray-800/80 backdrop-blur-xl rounded-2xl shadow-2xl ring-1 ring-gray-200 dark:ring-gray-700 p-8">
+        <h1 className="text-3xl md:text-4xl font-semibold mb-8 text-center tracking-tight">
           Fantasy Football Schedule Generator
         </h1>
 
@@ -120,15 +120,18 @@ export default function Home() {
           <label className="block font-semibold mb-2">Divisions</label>
           <div className="space-y-2" ref={divisionsRef}>
             {divisions.map(div => (
-              <div key={div.id} className="flex items-center p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+              <div
+                key={div.id}
+                className="flex items-center p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              >
                 <input
-                  className="border rounded px-3 py-2 flex-grow focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                  className="border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 flex-grow bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm transition-colors"
                   value={div.name ?? ''}
                   placeholder="Division name"
                   onChange={e => updateDivisionName(Number(div.id), e.target.value)}
                 />
                 <button
-                  className="ml-2 text-red-500 hover:text-red-700 transition-colors"
+                  className="ml-2 px-2 py-1 rounded-md text-red-500 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 transition-colors"
                   onClick={() => removeDivision(Number(div.id))}
                 >
                   Remove
@@ -137,14 +140,14 @@ export default function Home() {
             ))}
           </div>
           <button
-            className="mt-2 text-blue-600 hover:text-blue-800 transition-colors"
+            className="mt-3 inline-flex items-center text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline transition-colors"
             onClick={addDivision}
           >
             Add Division
           </button>
         </div>
 
-        <div className="mb-8 space-y-2">
+        <div className="mb-8 space-y-3">
           <label className="block font-semibold">Options</label>
           <label className="flex items-center">
             <input
@@ -169,7 +172,7 @@ export default function Home() {
             <input
               type="number"
               min={1}
-              className="border rounded px-3 py-2 w-24 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+              className="border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 w-24 bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm transition-colors"
               value={options.numWeeks ?? 13}
               onChange={e => setOptions({ ...options, numWeeks: Number(e.target.value) })}
             />
@@ -180,15 +183,18 @@ export default function Home() {
           <label className="block font-semibold mb-2">Teams</label>
           <div className="space-y-2" ref={teamsRef}>
             {teams.map((team, idx) => (
-              <div key={idx} className="flex items-center p-2 rounded hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+              <div
+                key={idx}
+                className="flex items-center p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              >
                 <input
-                  className="border rounded px-3 py-2 flex-grow focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                  className="border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 flex-grow bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm transition-colors"
                   value={team.name ?? ''}
                   placeholder="Team name"
                   onChange={e => updateTeam(idx, { name: e.target.value })}
                 />
                 <select
-                  className="border rounded px-3 py-2 ml-2 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+                  className="border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 ml-2 bg-white dark:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm transition-colors"
                   value={Number(team.divisionId)}
                   onChange={e => updateTeam(idx, { divisionId: Number(e.target.value) })}
                 >
@@ -199,7 +205,7 @@ export default function Home() {
                   ))}
                 </select>
                 <button
-                  className="ml-2 text-red-500 hover:text-red-700 transition-colors"
+                  className="ml-2 px-2 py-1 rounded-md text-red-500 hover:text-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 transition-colors"
                   onClick={() => removeTeam(idx)}
                 >
                   Remove
@@ -208,7 +214,7 @@ export default function Home() {
             ))}
           </div>
           <button
-            className="mt-2 text-blue-600 hover:text-blue-800 transition-colors"
+            className="mt-3 inline-flex items-center text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline transition-colors"
             onClick={addTeam}
           >
             Add Team
@@ -216,14 +222,14 @@ export default function Home() {
         </div>
 
         <button
-          className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          className="mt-4 bg-blue-600 hover:bg-blue-700 text-white font-medium px-6 py-2 rounded-lg shadow-sm transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
           onClick={generate}
           disabled={loading}
         >
           {loading ? 'Generating...' : 'Generate Schedule'}
         </button>
 
-        {error && <p className="text-red-600 mt-4">{error}</p>}
+        {error && <p className="text-red-500 font-medium mt-4">{error}</p>}
 
         {schedule && schedule.matchups && (
           <div className="mt-8">
@@ -232,9 +238,9 @@ export default function Home() {
                 <button
                   key={i}
                   onClick={() => setSelectedWeek(i)}
-                  className={`px-3 py-1 rounded-full text-sm transition-colors ${
+                  className={`px-3 py-1 rounded-full text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
                     selectedWeek === i
-                      ? 'bg-blue-600 text-white'
+                      ? 'bg-blue-600 text-white shadow'
                       : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600'
                   }`}
                 >
@@ -244,7 +250,7 @@ export default function Home() {
             </div>
             <button
               onClick={downloadCSV}
-              className="mb-4 bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors"
+              className="mb-4 bg-green-600 hover:bg-green-700 text-white font-medium px-4 py-2 rounded-lg shadow-sm transition-all duration-200"
             >
               Download CSV
             </button>
@@ -252,7 +258,7 @@ export default function Home() {
               {schedule.matchups[selectedWeek]?.matchups?.map((m, j) => (
                 <div
                   key={j}
-                  className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800 shadow"
+                  className="flex items-center justify-between p-3 rounded-xl bg-gray-100 dark:bg-gray-800 ring-1 ring-gray-200 dark:ring-gray-700"
                 >
                   <span>{m.team1?.name}</span>
                   <span className="text-gray-500">vs</span>


### PR DESCRIPTION
## Summary
- refresh schedule generator layout with a soft gradient backdrop and refined card container
- enhance form inputs, buttons, and week selector with rounded edges, focus states, and subtle transitions

## Testing
- `npm run lint`
- `npm test` *(fails: host system missing browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68937c8dc5c0832ea7ee6f0597562377