### PR TITLE
style: refine about page and nav design

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,18 +6,22 @@ export const metadata: Metadata = {
 
 export default function About() {
   return (
-    <main className="p-6 max-w-2xl mx-auto">
-      <h1 className="text-3xl font-bold mb-4">About the Scheduler</h1>
-      <p className="mb-4">
-        The Fantasy Football Schedule Generator creates balanced matchups using several constraints:
-      </p>
-      <ul className="list-disc pl-6 space-y-2">
-        <li>Every team plays every week.</li>
-        <li>No team has repeat matchups within any 4 week span.</li>
-        <li>
-          Soft constraint: out-of-division matchups are avoided in the final two weeks of the season when possible.
-        </li>
-      </ul>
+    <main className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center p-6">
+      <section className="max-w-2xl w-full bg-white/70 dark:bg-gray-900/70 backdrop-blur rounded-xl shadow-lg p-8 text-gray-700 dark:text-gray-300">
+        <h1 className="text-4xl font-semibold text-center mb-6 text-gray-900 dark:text-gray-100">
+          About the Scheduler
+        </h1>
+        <p className="mb-6 leading-relaxed text-center">
+          The Fantasy Football Schedule Generator creates balanced matchups using several constraints:
+        </p>
+        <ul className="list-disc pl-6 space-y-3">
+          <li>Every team plays every week.</li>
+          <li>No team has repeat matchups within any 4 week span.</li>
+          <li>
+            Soft constraint: out-of-division matchups are avoided in the final two weeks of the season when possible.
+          </li>
+        </ul>
+      </section>
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,9 +15,19 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased">
-        <nav className="p-4 space-x-4">
-          <Link href="/">Home</Link>
-          <Link href="/about">About</Link>
+        <nav className="sticky top-0 z-10 flex justify-center space-x-6 bg-white/80 dark:bg-gray-900/80 backdrop-blur border-b border-gray-200 dark:border-gray-800 p-4 text-sm">
+          <Link
+            href="/"
+            className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors"
+          >
+            Home
+          </Link>
+          <Link
+            href="/about"
+            className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors"
+          >
+            About
+          </Link>
         </nav>
         {children}
       </body>


### PR DESCRIPTION
## Summary
- add translucent, centered top nav with hover transitions
- restyle About page with gradient backdrop, card layout and improved typography

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68937c8dc5c0832ea7ee6f0597562377