### PR TITLE
chore: run smoke tests against schedwizard

### DIFF
--- a/.github/workflows/playwright-daily.yml
+++ b/.github/workflows/playwright-daily.yml
@@ -19,4 +19,4 @@ jobs:
       - run: npm test
         env:
           CI: true
-          PLAYWRIGHT_TEST_BASE_URL: https://ff-schedule-generator-fe.vercel.app
+          PLAYWRIGHT_TEST_BASE_URL: https://www.schedwizard.com


### PR DESCRIPTION
## Summary
- point daily Playwright smoke tests to https://www.schedwizard.com

## Testing
- `npx playwright install` *(fails: server returned code 403 body 'Domain forbidden')*
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68938071c764832eaad655dc7e3b9908