### PR TITLE
feat: add football-themed loading overlay for schedule generation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -231,44 +231,59 @@ export default function Home() {
 
         {error && <p className="text-red-600 mt-4">{error}</p>}
 
-        {schedule && schedule.matchups && (
-          <div className="mt-8">
-            <div className="flex flex-wrap gap-2 mb-4">
-              {schedule.matchups.map((_, i) => (
-                <button
-                  key={i}
-                  onClick={() => setSelectedWeek(i)}
-                  className={`px-3 py-1 rounded-full text-sm transition-colors ${
-                    selectedWeek === i
-                      ? 'bg-blue-600 text-white'
-                      : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600'
-                  }`}
-                >
-                  Week {i + 1}
-                </button>
-              ))}
-            </div>
-            <button
-              onClick={downloadCSV}
-              className="mb-4 bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors"
-            >
-              Download CSV
-            </button>
-            <div className="space-y-2" ref={scheduleRef}>
-              {schedule.matchups[selectedWeek]?.matchups?.map((m, j) => (
-                <div
-                  key={j}
-                  className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800 shadow"
-                >
-                  <span>{m.team1?.name}</span>
-                  <span className="text-gray-500">vs</span>
-                  <span>{m.team2?.name}</span>
-                </div>
-              ))}
-            </div>
+      {schedule && schedule.matchups && (
+        <div className="mt-8">
+          <div className="flex flex-wrap gap-2 mb-4">
+            {schedule.matchups.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setSelectedWeek(i)}
+                className={`px-3 py-1 rounded-full text-sm transition-colors ${
+                  selectedWeek === i
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600'
+                }`}
+              >
+                Week {i + 1}
+              </button>
+            ))}
           </div>
-        )}
-      </section>
-    </main>
+          <button
+            onClick={downloadCSV}
+            className="mb-4 bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-lg transition-colors"
+          >
+            Download CSV
+          </button>
+          <div className="space-y-2" ref={scheduleRef}>
+            {schedule.matchups[selectedWeek]?.matchups?.map((m, j) => (
+              <div
+                key={j}
+                className="flex items-center justify-between p-3 rounded-lg bg-gray-50 dark:bg-gray-800 shadow"
+              >
+                <span>{m.team1?.name}</span>
+                <span className="text-gray-500">vs</span>
+                <span>{m.team2?.name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+    {loading && (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+        <div className="flex flex-col items-center space-y-4">
+          <div className="relative flex items-center justify-center">
+            <div
+              className="h-24 w-24 rounded-full bg-gradient-to-b from-green-600 to-green-700 flex items-center justify-center animate-pulse"
+            >
+              <span className="text-5xl animate-bounce">🏈</span>
+            </div>
+            <div className="absolute inset-0 rounded-full border-4 border-green-400 opacity-60 animate-ping"></div>
+          </div>
+          <p className="text-white text-lg font-semibold">Huddling up the schedule...</p>
+        </div>
+      </div>
+    )}
+  </main>
   )
 }


### PR DESCRIPTION
## Summary
- replace generic spinner with football-themed loading overlay while schedules are generated

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893f0bae560832e8fee50dcf2b890b3