### PR TITLE
feat: default to five teams per division

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, Fragment } from 'react'
+import { useState, Fragment } from 'react'
 import { scheduler } from 'ff-schedule-protos/dist/scheduler'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -15,10 +15,12 @@ export default function Home() {
     { name: 'Team 2', divisionId: 1 },
     { name: 'Team 3', divisionId: 1 },
     { name: 'Team 4', divisionId: 1 },
-    { name: 'Team 5', divisionId: 2 },
+    { name: 'Team 5', divisionId: 1 },
     { name: 'Team 6', divisionId: 2 },
     { name: 'Team 7', divisionId: 2 },
-    { name: 'Team 8', divisionId: 2 }
+    { name: 'Team 8', divisionId: 2 },
+    { name: 'Team 9', divisionId: 2 },
+    { name: 'Team 10', divisionId: 2 }
   ])
   const [schedule, setSchedule] = useState<scheduler.IScheduleResponse | null>(null)
   const [loading, setLoading] = useState(false)

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -23,13 +23,13 @@ test('allows schedule generation and team/division management', async ({ page })
   await expect(divisionInputs).toHaveCount(2);
 
   const teamInputs = page.getByPlaceholder('Team name');
-  await expect(teamInputs).toHaveCount(8);
+  await expect(teamInputs).toHaveCount(10);
   await page.getByRole('button', { name: 'Add Team' }).first().click();
-  await expect(teamInputs).toHaveCount(9);
+  await expect(teamInputs).toHaveCount(11);
   const newTeam = teamInputs.last();
   await newTeam.fill('Temp');
   await page.getByRole('button', { name: 'Remove team' }).last().click();
-  await expect(teamInputs).toHaveCount(8);
+  await expect(teamInputs).toHaveCount(10);
 
   await page.getByLabel('Play teams in division twice').check();
   await page.getByLabel('Play teams out of division once').check();


### PR DESCRIPTION
## Summary
- default to 5 teams in each division
- update Playwright tests for new team counts

## Testing
- `npm run lint`
- `npm test` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_689d4d41ab90832e95bc27eda9658b85