### PR TITLE
feat: default to five teams per division and 13 weeks

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,32 +1,32 @@
 'use client'
 
-import { useState, useRef, Fragment } from 'react'
+import { useState, Fragment } from 'react'
 import { scheduler } from 'ff-schedule-protos/dist/scheduler'
 import { useAutoAnimate } from '@formkit/auto-animate/react'
 import { motion, AnimatePresence } from 'framer-motion'
 
 export default function Home() {
-  const [divisions, setDivisions] = useState<scheduler.IDivision[]>([
+  const initialDivisions: scheduler.IDivision[] = [
     { id: 1, name: 'AFC' },
     { id: 2, name: 'NFC' }
-  ])
-  const [teams, setTeams] = useState<scheduler.ITeam[]>([
-    { name: 'Team 1', divisionId: 1 },
-    { name: 'Team 2', divisionId: 1 },
-    { name: 'Team 3', divisionId: 1 },
-    { name: 'Team 4', divisionId: 1 },
-    { name: 'Team 5', divisionId: 2 },
-    { name: 'Team 6', divisionId: 2 },
-    { name: 'Team 7', divisionId: 2 },
-    { name: 'Team 8', divisionId: 2 }
-  ])
+  ]
+  const DEFAULT_TEAMS_PER_DIVISION = 5
+  const initialTeams: scheduler.ITeam[] = initialDivisions.flatMap((div, divIndex) =>
+    Array.from({ length: DEFAULT_TEAMS_PER_DIVISION }, (_, i) => ({
+      name: `Team ${divIndex * DEFAULT_TEAMS_PER_DIVISION + i + 1}`,
+      divisionId: div.id
+    }))
+  )
+
+  const [divisions, setDivisions] = useState<scheduler.IDivision[]>(initialDivisions)
+  const [teams, setTeams] = useState<scheduler.ITeam[]>(initialTeams)
   const [schedule, setSchedule] = useState<scheduler.IScheduleResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [options, setOptions] = useState<scheduler.IOptions>({
     inDivisionPlayTwice: true,
     outOfDivisionPlayOnce: true,
-    numWeeks: 14
+    numWeeks: 13
   })
   const [selectedWeek, setSelectedWeek] = useState(0)
 

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -23,17 +23,18 @@ test('allows schedule generation and team/division management', async ({ page })
   await expect(divisionInputs).toHaveCount(2);
 
   const teamInputs = page.getByPlaceholder('Team name');
-  await expect(teamInputs).toHaveCount(8);
+  await expect(teamInputs).toHaveCount(10);
   await page.getByRole('button', { name: 'Add Team' }).first().click();
-  await expect(teamInputs).toHaveCount(9);
+  await expect(teamInputs).toHaveCount(11);
   const newTeam = teamInputs.last();
   await newTeam.fill('Temp');
   await page.getByRole('button', { name: 'Remove team' }).last().click();
-  await expect(teamInputs).toHaveCount(8);
+  await expect(teamInputs).toHaveCount(10);
 
   await page.getByLabel('Play teams in division twice').check();
   await page.getByLabel('Play teams out of division once').check();
   const weeksInput = page.getByLabel('Number of weeks');
+  await expect(weeksInput).toHaveValue('13');
   await weeksInput.fill('12');
   await expect(weeksInput).toHaveValue('12');
 


### PR DESCRIPTION
## Summary
- generate initial five-team divisions programmatically
- default schedules to 13 weeks and test default value

## Testing
- `npm run lint`
- `npx playwright install` *(fails: Download failed: server returned code 403)*
- `npm test` *(fails: browser executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_689d4d41ab90832e95bc27eda9658b85